### PR TITLE
Classify `population:crossref` & `language:crossref` as`oboInOwl:hasDbXref`

### DIFF
--- a/src/ontology/afpo-edit.ofn
+++ b/src/ontology/afpo-edit.ofn
@@ -476,6 +476,7 @@ SubAnnotationPropertyOf(<http://purl.obolibrary.org/obo/AfPO_0000089> <http://pu
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> <http://purl.obolibrary.org/obo/AfPO_0000152> <https://orcid.org/0000-0001-9988-3250>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.obolibrary.org/obo/AfPO_0000152> "2020-05-31T21:33:12.445061Z")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/AfPO_0000152> "population:genetic:study")
+SubAnnotationPropertyOf(<http://purl.obolibrary.org/obo/AfPO_0000152> <http://purl.obolibrary.org/obo/AfPO_0000600>)
 
 # Annotation Property: <http://purl.obolibrary.org/obo/AfPO_0000221> (language:ISO639-3:description)
 
@@ -502,6 +503,7 @@ SubAnnotationPropertyOf(<http://purl.obolibrary.org/obo/AfPO_0000223> <http://pu
 AnnotationAssertion(<http://purl.org/dc/terms/contributor> <http://purl.obolibrary.org/obo/AfPO_0000226> <https://orcid.org/0000-0001-9988-3250>)
 AnnotationAssertion(<http://www.geneontology.org/formats/oboInOwl#creation_date> <http://purl.obolibrary.org/obo/AfPO_0000226> "2020-06-03T17:56:59.458188Z")
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/AfPO_0000226> "population:microbiome:study")
+SubAnnotationPropertyOf(<http://purl.obolibrary.org/obo/AfPO_0000226> <http://purl.obolibrary.org/obo/AfPO_0000600>)
 
 # Annotation Property: <http://purl.obolibrary.org/obo/AfPO_0000230> (language:glottolog:description)
 

--- a/src/ontology/afpo-edit.ofn
+++ b/src/ontology/afpo-edit.ofn
@@ -620,10 +620,12 @@ SubAnnotationPropertyOf(<http://purl.obolibrary.org/obo/AfPO_0000568> <http://pu
 # Annotation Property: <http://purl.obolibrary.org/obo/AfPO_0000600> (population:crossref)
 
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/AfPO_0000600> "population:crossref"@en)
+SubAnnotationPropertyOf(<http://purl.obolibrary.org/obo/AfPO_0000600> <http://www.geneontology.org/formats/oboInOwl#hasDbXref>)
 
 # Annotation Property: <http://purl.obolibrary.org/obo/AfPO_0000601> (language:crossref)
 
 AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/AfPO_0000601> "language:crossref")
+SubAnnotationPropertyOf(<http://purl.obolibrary.org/obo/AfPO_0000601> <http://www.geneontology.org/formats/oboInOwl#hasDbXref>)
 
 # Annotation Property: <http://purl.org/dc/terms/description> (description)
 
@@ -636,6 +638,10 @@ AnnotationAssertion(rdfs:label <http://purl.org/dc/terms/license> "license")
 # Annotation Property: <http://purl.org/dc/terms/title> (title)
 
 AnnotationAssertion(rdfs:label <http://purl.org/dc/terms/title> "title")
+
+# Annotation Property: <http://www.geneontology.org/formats/oboInOwl#hasDbXref> (has database cross reference)
+
+AnnotationAssertion(rdfs:label <http://www.geneontology.org/formats/oboInOwl#hasDbXref> "has database cross reference")
 
 
 ############################


### PR DESCRIPTION
Fixes #35
Related to #16